### PR TITLE
Update link to main site from docs to use same browser tab

### DIFF
--- a/moonwave.toml
+++ b/moonwave.toml
@@ -48,6 +48,7 @@ position = "right"
 alt = "Kohl's Admin"
 href = "https://kohl.gg"
 src = "/logo-load.svg"
+target = "_self"
 
 [footer]
 style = "dark"


### PR DESCRIPTION
Sets the target of the logo href in the docs to be `_self`, causing the link to open in the active tab.