### PR TITLE
Fixed documentation links being incorrect in certain cases when navigating

### DIFF
--- a/docs/custom_commands.mdx
+++ b/docs/custom_commands.mdx
@@ -18,7 +18,7 @@ By default this folder will contain some example addons.
 ## Addon Setup
 
 <!-- TODO: make an addons page! -->
-All custom commands are part of an [Addon](Addons). For this section we will create addons that only create custom commands, but in later parts we will show the extent of what addons can do.
+All custom commands are part of an [Addon](/docs/addons). For this section we will create addons that only create custom commands, but in later parts we will show the extent of what addons can do.
 
 All addons are module scripts that return a function. To start, create a module script and inside of it write the following:
 
@@ -37,7 +37,7 @@ Appending "Client" or "Server" to the end of an addon file's name will make it o
 
 ## Creating a Custom Command
 
-To create a custom command, you must register it with the [Registry](../api/Registry), using [registerCommand()](../api/Registry#registerCommand).
+To create a custom command, you must register it with the [Registry](/api/Registry), using [registerCommand()](/api/Registry#registerCommand).
 
 Using this, our module becomes:
 
@@ -47,7 +47,7 @@ return function(_K)
 end
 ```
 
-`commandDefinition` is a placeholder for the real contents of our command! Commands require a lot of information, structured in a [commandDefinition](../api/Registry#CommandDefinition).
+`commandDefinition` is a placeholder for the real contents of our command! Commands require a lot of information, structured in a [commandDefinition](/api/Registry#CommandDefinition).
 
 ```lua
 type commandDefinition {

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -30,8 +30,8 @@ This documentation is structured to help you:
 - **Use Features**: Explore the various commands and features available in KA.
 - **Troubleshoot**: Find solutions to common issues and get support.
 
-We recommend starting with the [Getting Started](getting-started/installation) guide if you are new to Kohl's Admin. For more advanced topics, you can explore the other sections of this documentation.
+We recommend starting with the [Getting Started](/docs/getting-started/installation) guide if you are new to Kohl's Admin. For more advanced topics, you can explore the other sections of this documentation.
 
 ---
 
-We hope this documentation helps you get the most out of Kohl's Admin. If you have any questions or need further assistance, don't hesitate to reach out to the community or consult the [Support](support) section.
+We hope this documentation helps you get the most out of Kohl's Admin. If you have any questions or need further assistance, don't hesitate to reach out to the community or consult the [Support](/docs/support) section.

--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -27,7 +27,7 @@ In the Discord server, you will find:
 
 Before reaching out for help, make sure to review the documentation. Many common questions and issues are addressed in the following sections:
 
-- **[Getting Started](getting-started)**: A step-by-step guide to installing and configuring Kohl's Admin.
+- **[Getting Started](/docs/getting-started/installation)**: A step-by-step guide to installing and configuring Kohl's Admin.
 <!-- - **[Troubleshooting](troubleshooting.md)**: Solutions to common problems you might encounter. -->
 
 ## Contact Us


### PR DESCRIPTION
Previously, when navigating the documentation links, they can incorrectly link to non-existent pages due to trailing slashes appearing in certain cases. This fixes it by removing relative linking and instead has links start from the root.