### PR TITLE
Add support for development containers for Rojo and Moonwave

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,5 +21,6 @@
 			"label": "Rojo"
 		}
 	},
-	"postCreateCommand": "aftman install --no-trust-check && npm i -g moonwave"
+	"postCreateCommand": "aftman install --no-trust-check && npm i -g moonwave",
+	"remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+	"name": "Kohl's Admin",
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"features": {
+		"ghcr.io/ryanlua/features/rojo:0.2.0": {
+			"version": "latest",
+			"toolchainManager": "aftman"
+		},
+		"ghcr.io/devcontainers/features/node:1": {}
+	},
+	"forwardPorts": [
+		3000,
+		34872
+	],
+	"portsAttributes": {
+		"3000": {
+			"label": "Moonwave",
+			"onAutoForward": "openPreview"
+		},
+		"34872": {
+			"label": "Rojo"
+		}
+	},
+	"postCreateCommand": "aftman install --no-trust-check && npm i -g moonwave"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /build
 sourcemap.json
 !.moonwave/
+!.devcontainer
 !.gitignore
 !.github


### PR DESCRIPTION
Adds a [dev container](https://containers.dev/) configuration for running Rojo and Moonwave, making contributing and development easier.

This PR aims towards newcomers and first-time contributors to make developing and contributing to Kohl's Admin easier by streamlining the tool install process and allowing them to not have to download a code editor such as VS Code, using their browser (VS Code for the Web) as the code editor, work or use this repo.

Quick run down on dev containers:

* Allows you to develop in a container for supported tools (GitHub Codespaces, VS Code, Gitpod, etc.)
* Automatically install the tools you need for development easily
* Works in the browser through GitHub Codespaces, so you don't need VS Code installed to develop at all (Roblox Studio is still needed if you want to sync)

What the dev container in this PR supports through VS Code & GitHub Codespaces:

* Building and serving the documentation site locally
* Building and syncing Kohl's Admin through there respective `.project.json` files
* Installing Aftman tools and Node.js dependencies

What's next after this PR for improvement is to include VS Code extensions and add documentation for using this repo in a dev container.

## Files Changed

* Create `.devcontainer.json` for dev container configuration
* Create `dependabot.yml` for automatically updating the dev container configuration
* Update `.gitignore` to not ignore the `.devcontainer` directory

### Dev Container Configuration (`.devcontainer.json`)

Explanation of that the `.devcontainer.json` does

* Installs [my dev container feature](https://github.com/RyanLua/features) that installs Rojo and a toolchain manager (Aftman for this case) and the Node.js feature for documentation
* Forward ports `3000` for documentation and `34872` for Rojo
* Install Aftman tools and install Moonwave
* Run as root so we can install the tools properly

## Notes

I own the https://ghcr.io/ryanlua/features/rojo:0.2.0 feature which this PR adds, so I am a bit biased but there is no other feature that installs Rojo or allows you to install Roblox toolchain managers.

For a full list of known issues, philosophy, documentation, refer to https://github.com/RyanLua/templates and https://github.com/RyanLua/features

### Documentation

It is recommended that you add documentation that the repository supports dev containers and how to develop them in one. There is also a badge you could optionally add to the README:

```
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kohls-admin/main?quickstart=1)
```
[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kohls-admin/main?quickstart=1)

I don't know what you want exactly to add to the documentation so I have left it out in my PR but you can request for me to add it if you don't.

### Additional dev container reading

For information about dev containers and what they exactly are.

* https://containers.dev/
* https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers
* https://microsoft.github.io/code-with-engineering-playbook/developer-experience/devcontainers-getting-started/
* https://code.visualstudio.com/docs/devcontainers/containers

###### I'm open to any feedback or changes suggested for this PR.
